### PR TITLE
Fix for the Cross-site Scripting (XSS) Vulnerability

### DIFF
--- a/htdocs/filefunc.inc.php
+++ b/htdocs/filefunc.inc.php
@@ -165,7 +165,7 @@ if (! defined('NOCSRFCHECK') && empty($dolibarr_nocsrfcheck))
     	if ($csrfattack)
     	{
     		//print 'NOCSRFCHECK='.defined('NOCSRFCHECK').' REQUEST_METHOD='.$_SERVER['REQUEST_METHOD'].' HTTP_HOST='.$_SERVER['HTTP_HOST'].' HTTP_REFERER='.$_SERVER['HTTP_REFERER'];
-    		print "Access refused by CSRF protection in main.inc.php. Referer of form (".$_SERVER['HTTP_REFERER'].") is outside the server that serve this page (with method = ".$_SERVER['REQUEST_METHOD'].").\n";
+    		print "Access refused by CSRF protection in main.inc.php. Referer of form (".htmlspecialchars($_SERVER['HTTP_REFERER'], ENT_QUOTES, 'UTF-8').") is outside the server that serve this page (with method = ".$_SERVER['REQUEST_METHOD'].").\n";
         	print "If you access your server behind a proxy using url rewriting, you might check that all HTTP headers are propagated (or add the line \$dolibarr_nocsrfcheck=1 into your conf.php file to remove this security check).\n";
     		die;
     	}


### PR DESCRIPTION
The vulnerability's root cause is not in the "htdocs/user/passwordforgotten.php" file and it's in the "htdocs/filefunc.inc.php".

The proof-of-concept of this vulnerability helped me find the root cause of this vulnerability:
https://tufangungor.github.io/exploit/2020/01/18/dolibarr-10.0.6-xss-in-http-header.html

The response was: "_Access refused by CSRF protection in main.inc.php. Referer of form (_" which shows that the JavaScript code got inside the "htdocs/filefunc.inc.php" unsanitized.

The fix is the "**htmlspecialchars()**" function with UTF-8 encoding and ENT_QUOTES which will sanitize the JavaScript payload from the Referer HTTP Header.

**Fixed!** :+1: 