### PR TITLE
Fix for Self XSS vuln in dolibarr

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -3911,7 +3911,7 @@ function dol_print_error($db = '', $error = '', $errors = null)
 		{
 			$out .= "<b>".$langs->trans("OS").":</b> ".php_uname()."<br>\n";
 		}
-		$out .= "<b>".$langs->trans("UserAgent").":</b> ".$_SERVER["HTTP_USER_AGENT"]."<br>\n";
+		$out .= "<b>".$langs->trans("UserAgent").":</b> ".dol_htmlentities($_SERVER["HTTP_USER_AGENT"], ENT_COMPAT, 'UTF-8)."<br>\n";
 		$out .= "<br>\n";
 		$out .= "<b>".$langs->trans("RequestedUrl").":</b> ".dol_htmlentities($_SERVER["REQUEST_URI"], ENT_COMPAT, 'UTF-8')."<br>\n";
 		$out .= "<b>".$langs->trans("Referer").":</b> ".(isset($_SERVER["HTTP_REFERER"]) ?dol_htmlentities($_SERVER["HTTP_REFERER"], ENT_COMPAT, 'UTF-8') : '')."<br>\n";

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -3911,7 +3911,7 @@ function dol_print_error($db = '', $error = '', $errors = null)
 		{
 			$out .= "<b>".$langs->trans("OS").":</b> ".php_uname()."<br>\n";
 		}
-		$out .= "<b>".$langs->trans("UserAgent").":</b> ".dol_htmlentities($_SERVER["HTTP_USER_AGENT"], ENT_COMPAT, 'UTF-8)."<br>\n";
+		$out .= "<b>".$langs->trans("UserAgent").":</b> ".dol_htmlentities($_SERVER["HTTP_USER_AGENT"], ENT_COMPAT, 'UTF-8')."<br>\n";
 		$out .= "<br>\n";
 		$out .= "<b>".$langs->trans("RequestedUrl").":</b> ".dol_htmlentities($_SERVER["REQUEST_URI"], ENT_COMPAT, 'UTF-8')."<br>\n";
 		$out .= "<b>".$langs->trans("Referer").":</b> ".(isset($_SERVER["HTTP_REFERER"]) ?dol_htmlentities($_SERVER["HTTP_REFERER"], ENT_COMPAT, 'UTF-8') : '')."<br>\n";


### PR DESCRIPTION
### 📊 Metadata *

_Please enter the direct URL for this bounty on huntr.dev. This is compulsory and will help us process your bounty submission quicker._

#### Bounty URL: https://www.huntr.dev/bounties/2-packagist-dolibarr

### ⚙️ Description *

A lack of escaping exists in the **dol_print_error** (in **htdocs/core/lib/functions.lib.php** file).
This could lead to XSS.

### 💻 Technical Description *

The fix simply html-entity encodes the var before printing it.

### 🐛 Proof of Concept (PoC) *

1. Log into your dolibarr instance
2. Change your browser user-agent by appending something like <script>alert(document.domain);</script>
3. Modify the URL in order to throw an error (for example: http://dolibarr/document.php?modulepart=.&attachment=0&file=dddd&&entity=10&&entity=1000&&entity=101&mainmenu=home)
4. No more XSS, the payload string is displayed instead of being executed

### 🔥 Proof of Fix (PoF) *
![pof](https://user-images.githubusercontent.com/4253885/89431498-53153900-d740-11ea-9d44-b03d091ab680.PNG)



### 👍 User Acceptance Testing (UAT)

